### PR TITLE
Add Real World OCaml packages to opam part

### DIFF
--- a/lib/autoparts/packages/opam.rb
+++ b/lib/autoparts/packages/opam.rb
@@ -26,6 +26,9 @@ module Autoparts
       def install
         Dir.chdir(extracted_archive_path + name_with_version) do
           system 'make install'
+          system 'opam init -y -a'
+          system 'opam install -y async yojson core_extended core_bench cohttp cryptokit menhir utop'
+          system 'curl https://gist.githubusercontent.com/avsm/9874360/raw/9290fa85bee7313b7acecc5393c669c522bb6a52/.ocamlinit >> ~/.ocamlinit'
         end
       end
     end


### PR DESCRIPTION
This (untested) diff initializes OPAM and installs the packages from https://realworldocaml.org/install into the opam repository (`~/.opam`).  This makes them easily available to users without having to leave it compiling for 30 minutes (and also saving Codio container resources).

The only thing else they need to do after this should be to:

```
$ eval `opam config env`
$ utop
```

It also adds the necessary `.ocamlinit` file from a Gist.  There may be a way to embed this in the part to avoid a GitHub dependency like this.

Anyway, if this diff is headed in the right direction, we would love to recommend Codio to new readers of Real World OCaml as the best way to get started instantly by forking the https://github.com/realworldocaml/examples repository into Codio.
