### PR TITLE
Fixed gopath issue

### DIFF
--- a/lib/autoparts/packages/go_lang.rb
+++ b/lib/autoparts/packages/go_lang.rb
@@ -26,11 +26,12 @@ module Autoparts
         <<-EOS.unindent
           export GOROOT=#{prefix_path}
           export GOPATH=#{go_packages}
+          export PATH=$PATH:$GOPATH/bin
         EOS
       end
 
       def go_packages
-        prefix_path + 'gopath'
+        Path.home + 'workspace'
       end
 
       def post_install


### PR DESCRIPTION
Go was installing properly but there were 2 problems.

First, the GOPATH environment variable was not being set properly. It actually should be set to /home/codio/workspace. 

Second, the $GOPATH/bin directory should be added to the PATH variable. When you write go code and run go install, it will create an executable and put it in the $GOPATH/bin directory. By adding this to the path, it makes it easy to run your code from any location. 
