### PR TITLE
added a boxpart: php5-phalcon

### DIFF
--- a/lib/autoparts/packages/php5_phalcon.rb
+++ b/lib/autoparts/packages/php5_phalcon.rb
@@ -1,0 +1,32 @@
+require 'autoparts/packages/php5_ext'
+
+
+module Autoparts
+  module Packages
+    class Php5Phalcon < Package
+      include Php5Ext
+
+      name 'php5-phalcon'
+      version '1.3.2'
+      description 'Phalcon web framework.'
+      source_url 'https://github.com/phalcon/cphalcon/archive/phalcon-v1.3.2.tar.gz'
+      source_sha1 '64eea8e384363a5582a59a910b1327dc97b7d355'
+      source_filetype 'tar.gz'
+      category Category::WEB_DEVELOPMENT
+
+      depends_on 'php5'
+
+      def php_extension_name
+         "phalcon"
+      end
+
+      def php_extension_dir
+         "cphalcon-phalcon-v1.3.2/build/64bits"
+      end
+
+      def php_compile_args
+         ['--enable-phalcon']
+      end
+    end
+  end
+end


### PR DESCRIPTION
Box part "php5-phalcon" added for the Phalcon PHP web framework (http://www.phalconphp.com).

I've tested the box part successfully on a Codio box, by creating and running a "hello world" PHP-Phalcon web application.

For details see the issue: https://github.com/codio/boxparts/issues/128

Please review/merge the pull request and build/upload the binary using "parts install  php5-phalcon --source", "parts archive php5-phalcon" and "parts upload php5-phalcon".
