### PR TITLE
Add the FreeTDS ./configure that worked locally

### DIFF
--- a/lib/autoparts/packages/freetds_azure.rb
+++ b/lib/autoparts/packages/freetds_azure.rb
@@ -11,13 +11,13 @@ module Autoparts
       category Category::LIBRARIES
 
       def install
-        Dir.chdir(name_with_version) do
+        Dir.chdir('freetds-0.91') do
           execute 'make', 'install'
         end
       end
 
       def compile
-        Dir.chdir(name_with_version) do
+        Dir.chdir('freetds-0.91') do
           args = [
             "--prefix=#{prefix_path}",
             '--enable-msdblib',


### PR DESCRIPTION
We're having issues with openssl working properly on Codio with FreeTDS
where we do not have that issue locally when installing FreeTDS from
Homebrew on a mac.  These are the configure flags that homebrew used and
we can successfully connect locally on a mac with tsql.
