### PR TITLE
Upgrade Maven

### DIFF
--- a/lib/autoparts/packages/maven.rb
+++ b/lib/autoparts/packages/maven.rb
@@ -5,10 +5,10 @@ module Autoparts
   module Packages
     class Maven < Package
       name 'maven'
-      version '3.2.1'
+      version '3.2.3'
       description 'Maven: A software project management and comprehension tool'
-      source_url 'http://www.us.apache.org/dist/maven/maven-3/3.2.1/binaries/apache-maven-3.2.1-bin.tar.gz'
-      source_sha1 '40e1bf0775fd3ebcac1dbeb61153b871b86b894f'
+      source_url 'http://www.us.apache.org/dist/maven/maven-3/3.2.3/binaries/apache-maven-3.2.3-bin.tar.gz'
+      source_sha1 '1ce6641f7dcb4fd5785bedcdca2979da83f6d23f'
       source_filetype 'tar.gz'
       category Category::DEVELOPMENT_TOOLS
 


### PR DESCRIPTION
I'm unsure if this really works, because I tried to install the new part and it didn't work:

```
=> Extracting archive...                                                                                                                              
=> Compiling...                                                                                                                                       
=> Installing...                                                                                                                                      
mv: cannot move `/home/codio/.parts/tmp/maven-3.2.3/apache-maven-3.2.3' to `/home/codio/.parts/packages/maven/3.2.3': No such file or directory       
parts: ERROR: "mv /home/codio/.parts/tmp/maven-3.2.3/apache-maven-3.2.3 /home/codio/.parts/packages/maven/3.2.3" failed                               
Aborting! 
```

Not sure why, though.
