### PR TITLE
BoxPart for Codio for installing Rust and Cargo by means of the rustup.sh script

### DIFF
--- a/lib/autoparts/packages/rustup.rb
+++ b/lib/autoparts/packages/rustup.rb
@@ -1,0 +1,28 @@
+# Copyright (c) 2014 Graham Cox <graham@grahamcox.co.uk>
+# This software is licensed under the [BSD 2-Clause license](https://raw.github.com/sazzer/boxparts/master/LICENSE).
+
+module Autoparts
+  module Packages
+    class RustUp < Package
+      name 'rustup'
+      version 'latest'
+      description 'Rust: A safe, concurrent, practical language, using the rustup.sh script for bleeding-edge installs'
+      category Category::PROGRAMMING_LANGUAGES
+
+      source_url 'https://static.rust-lang.org/rustup.sh'
+      source_filetype 'sh'
+
+      def install
+        File.chmod(0755, "./rustup-latest.sh")
+        execute './rustup-latest.sh', "--prefix=#{prefix_path}"
+      end
+      
+      def uninstall
+        File.chmod(0755, "./rustup-latest.sh")
+        execute './rustup-latest.sh', "--prefix=#{prefix_path}", "--uninstall"
+      end
+
+    end
+  end
+end
+


### PR DESCRIPTION
Rust is such a new language with so many changes happening all the time that it is often useful to have the absolute latest bleeding edge version installed. Rust-lang.org provide a shell script that will do this, and this Box Part makes use of that shell script to install the absolute latest version. (As such, the version I've put in is just "latest" and there's no SHA1 because this will possibly change very regularly)
