### PR TITLE
npm install gameboy fails because it is missing dependencies.

### DIFF
--- a/lib/autoparts/packages/libcairo2.rb
+++ b/lib/autoparts/packages/libcairo2.rb
@@ -1,0 +1,39 @@
+module Autoparts
+  module Packages
+    class Libcairo2 < Package
+      name 'libcairo2'
+      version '1.12.18'
+      description 'libcairo2: 2D graphics library with support for multiple output devices'
+      category Category::LIBRARIES
+
+      source_url 'http://cairographics.org/releases/cairo-1.12.18.tar.xz'
+      source_sha1 'a76940b58da9c83b8934264617135326c0918f9d'
+      source_filetype 'tar.xz'
+      
+      depends_on 'pixman'
+
+      def name_with_version
+        "cairo-#{version}"
+      end
+
+      def compile
+        Dir.chdir(name_with_version) do
+          args = [
+            "--prefix=#{prefix_path}",
+            ]
+          execute './configure', *args
+          execute 'make'
+        end
+      end
+      
+      def install
+        Dir.chdir(name_with_version) do
+          execute 'make install'
+        end
+      end
+      
+      
+      
+    end
+  end
+end

--- a/lib/autoparts/packages/libgif.rb
+++ b/lib/autoparts/packages/libgif.rb
@@ -1,0 +1,37 @@
+module Autoparts
+  module Packages
+    class Libgif < Package
+      name 'libgif'
+      version '4.1.6'
+      description 'GIFLIB: package of portable tools and library routines for working with GIF images'
+      category Category::LIBRARIES
+
+      source_url 'http://ftp.de.debian.org/debian/pool/main/g/giflib/giflib_4.1.6.orig.tar.gz'
+      source_sha1 '8649fa9c16f3300750f7089c79e652ddc750c832'
+      source_filetype 'tar.gz'
+
+      def name_with_version
+        "giflib-#{version}"
+      end
+
+      def compile
+        Dir.chdir(name_with_version) do
+          args = [
+            "--prefix=#{prefix_path}",
+            ]
+          execute './configure', *args
+          execute 'make'
+        end
+      end
+      
+      def install
+        Dir.chdir(name_with_version) do
+          execute 'make install'
+        end
+      end
+      
+      
+      
+    end
+  end
+end

--- a/lib/autoparts/packages/pixman.rb
+++ b/lib/autoparts/packages/pixman.rb
@@ -1,0 +1,38 @@
+module Autoparts
+  module Packages
+    class Pixman < Package
+      name 'pixman'
+      version '0.32.6'
+      description 'pixman: low-level software library for pixel manipulation, providing features such as image compositing and trapezoid rasterization'
+      category Category::LIBRARIES
+
+      source_url 'http://cairographics.org/releases/pixman-0.32.6.tar.gz'
+      source_sha1 '8791343cbf6d99451f4d08e8209d6ac11bf96df2'
+      source_filetype 'tar.gz'
+
+      def name_with_version
+        "pixman-#{version}"
+      end
+
+      def compile
+        Dir.chdir(name_with_version) do
+          
+          args = [
+            "--prefix=#{prefix_path}",
+            ]
+          execute './configure', *args
+          execute 'make'
+        end
+      end
+      
+      def install
+        Dir.chdir(name_with_version) do
+          execute 'make install'
+        end
+      end
+      
+      
+      
+    end
+  end
+end


### PR DESCRIPTION
These Box Parts add those dependencies to the system.
libcairo2 depends on pixman and libgif is a standard part of many Linux Distros.