### PR TITLE
update openldap

### DIFF
--- a/lib/autoparts/packages/openldap.rb
+++ b/lib/autoparts/packages/openldap.rb
@@ -2,10 +2,10 @@ module Autoparts
   module Packages
     class Openldap < Package
       name 'openldap'
-      version '2.4.39'
+      version '2.4.40'
       description 'OpenLDAP:  an open source implementation of the Lightweight Directory Access Protocol.'
-      source_url 'ftp://ftp.openldap.org/pub/OpenLDAP/openldap-release/openldap-2.4.39.tgz'
-      source_sha1 '2b8e8401214867c361f7212e7058f95118b5bd6c'
+      source_url 'ftp://ftp.openldap.org/pub/OpenLDAP/openldap-release/openldap-2.4.40.tgz'
+      source_sha1 '0cfac3b024b99de2e2456cc7254481b6644e0b96'
       source_filetype 'tgz'
       category Category::UTILITIES
 


### PR DESCRIPTION
@MaximKraev 
This is one I had a problem with in the large repo

checking if Berkeley DB version supported by BDB/HDB backends... no

configure: error: BerkeleyDB version incompatible with BDB/HDB backends

parts: ERROR: "./configure --prefix=/home/codio/.parts/packages/openldap/2.4.40 --enable-ldap --with-tls=openssl" failed