### PR TITLE
Fix missing cfg dir after installation.

### DIFF
--- a/lib/autoparts/packages/cppcheck.rb
+++ b/lib/autoparts/packages/cppcheck.rb
@@ -12,9 +12,9 @@ module Autoparts
 
       def compile
         args = [
-          "PREFIX=#{prefix_path}",
-          "SRCDIR=build",
-          "CFGDIR=cfg"
+          "PREFIX=",
+          "DESTDIR=#{prefix_path}",
+          "CFGDIR=#{prefix_path}/cfg"
         ]
         
         Dir.chdir(name_with_version) do   
@@ -24,7 +24,9 @@ module Autoparts
 
       def install
         args = [
-          "PREFIX=#{prefix_path}"
+          "PREFIX=",
+          "DESTDIR=#{prefix_path}",
+          "CFGDIR=/cfg"
         ]
         
         Dir.chdir(name_with_version) do 


### PR DESCRIPTION
There was a problem with the previous version, the cfg directory wasn't being copied to the installation path. 
Although the cppcheck binary would install and run, the problem wasn't apparent until running it against a source file.

The cfg directory is now correctly added to the installation path.