### PR TITLE
Updating google app engine sdk versions from 1.9.17 to 1.9.21

### DIFF
--- a/lib/autoparts/packages/googleappengine.rb
+++ b/lib/autoparts/packages/googleappengine.rb
@@ -5,12 +5,12 @@ module Autoparts
   module Packages
     class GoogleAppEngine < Package
       name 'googleappengine'
-      version '1.9.17'
+      version '1.9.21'
       description 'Google App Engine for Python/PHP: A CLI for managing Google App Engine cloud services for Python and PHP'
       category Category::DEPLOYMENT
 
-      source_url 'https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.17.zip'
-      source_sha1 'eec50aaf922d3b21623fda1b90e199c3ffa9e16e'
+      source_url 'https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.21.zip'
+      source_sha1 'ad616c194337614888aad97c38792507dc706413'
       source_filetype 'zip'
 
       def install

--- a/lib/autoparts/packages/googleappenginego.rb
+++ b/lib/autoparts/packages/googleappenginego.rb
@@ -2,12 +2,12 @@ module Autoparts
   module Packages
     class GoogleAppEngineGo < Package
       name 'googleappenginego'
-      version '1.9.17'
+      version '1.9.21'
       description 'Google App Engine for Go: A CLI for managing Google App Engine cloud services for Go'
       category Category::DEPLOYMENT
 
-      source_url 'https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_linux_amd64-1.9.17.zip'
-      source_sha1 'bdcf47c48b6e099a6596f9124fc29988dd4b874f'
+      source_url 'https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_linux_amd64-1.9.21.zip'
+      source_sha1 '704fa8b7e251048b7cf2912d645ba9b1521367d6'
       source_filetype 'zip'
 
       def install

--- a/lib/autoparts/packages/googleappenginejava.rb
+++ b/lib/autoparts/packages/googleappenginejava.rb
@@ -2,12 +2,12 @@ module Autoparts
   module Packages
     class GoogleAppEngineJava < Package
       name 'googleappenginejava'
-      version '1.9.17'
+      version '1.9.21'
       description 'Google App Engine Java: A CLI for managing Google App Engine cloud services for Java'
       category Category::DEPLOYMENT
 
-      source_url 'https://storage.googleapis.com/appengine-sdks/featured/appengine-java-sdk-1.9.17.zip'
-      source_sha1 'ca0bbae7e6c24dfe90cc06be384d594840dd2251'
+      source_url 'https://storage.googleapis.com/appengine-sdks/featured/appengine-java-sdk-1.9.21.zip'
+      source_sha1 'a405c32aa72d90c404fff0cab59624bf44d9c43d'
       source_filetype 'zip'
 
       def install


### PR DESCRIPTION
The runtime setting for php has changed and was causing me issues, mostly complaints about it validating php vs php55. This should fix the issues I was having, and probably others.  

See release notes:
https://code.google.com/p/googleappengine/wiki/SdkReleaseNotes